### PR TITLE
[Fix] Apply Steam executable flag on depot download 

### DIFF
--- a/src/launch/stages/preflight.rs
+++ b/src/launch/stages/preflight.rs
@@ -26,6 +26,22 @@ fn preflight_error(kind: LaunchErrorKind, details: &str) -> LaunchError {
     LaunchError::new(kind, format!("[Preflight] {}", details))
 }
 
+/// Game-owned binary safe to auto-chmod?
+#[cfg(unix)]
+fn native_game_binary(ctx: &PipelineContext, program: &Path) -> bool {
+    let is_native = matches!(
+        ctx.launch_info.as_ref().map(|i| i.target),
+        Some(crate::steam_client::LaunchTarget::NativeLinux)
+    );
+    if !is_native {
+        return false;
+    }
+    ctx.app
+        .as_ref()
+        .and_then(|app| app.install_path.as_ref())
+        .is_some_and(|install_path| program.starts_with(install_path))
+}
+
 #[async_trait]
 impl PipelineStage for PreflightStage {
     fn name(&self) -> &str { "Preflight" }
@@ -159,10 +175,31 @@ impl PipelineStage for PreflightStage {
             let mut check = PreflightCheck { name: "Runner Executability".into(), status: true, details: "OK".into() };
             if let Ok(metadata) = std::fs::metadata(runner_file) {
                 if metadata.is_file() && metadata.permissions().mode() & 0o111 == 0 {
-                    check.status = false;
-                    check.details = format!("Runner binary is not executable: {}", runner_file.display());
-                    final_res = Err(preflight_error(LaunchErrorKind::Permission, &check.details)
-                        .with_context("runner_path", runner_path.clone()));
+                    // Native launches self-heal missing exec bit.
+                    if native_game_binary(ctx, runner_file) {
+                        let mut permissions = metadata.permissions();
+                        permissions.set_mode(permissions.mode() | 0o755);
+                        match std::fs::set_permissions(runner_file, permissions) {
+                            Ok(()) => {
+                                check.details = format!("Added executable permission: {}", runner_file.display());
+                            }
+                            Err(e) => {
+                                check.status = false;
+                                check.details = format!(
+                                    "Game binary is not executable and chmod failed ({}): {}",
+                                    e,
+                                    runner_file.display()
+                                );
+                                final_res = Err(preflight_error(LaunchErrorKind::Permission, &check.details)
+                                    .with_context("runner_path", runner_path.clone()));
+                            }
+                        }
+                    } else {
+                        check.status = false;
+                        check.details = format!("Runner binary is not executable: {}", runner_file.display());
+                        final_res = Err(preflight_error(LaunchErrorKind::Permission, &check.details)
+                            .with_context("runner_path", runner_path.clone()));
+                    }
                 }
             }
             checks.push(check);

--- a/src/launch/stages/preflight_tests.rs
+++ b/src/launch/stages/preflight_tests.rs
@@ -123,6 +123,58 @@ async fn test_preflight_bogus_relative_runner_fails() {
 
 #[tokio::test]
 #[cfg(unix)]
+async fn test_preflight_native_game_self_heals_exec_bit() {
+    use std::os::unix::fs::PermissionsExt;
+    use crate::core::models::LibraryGame;
+    use crate::steam_client::{LaunchInfo, LaunchTarget};
+
+    let tmp = tempdir().unwrap();
+    let exe = tmp.path().join("Game.AppImage");
+    fs::write(&exe, "dummy").unwrap();
+    let mut perms = fs::metadata(&exe).unwrap().permissions();
+    perms.set_mode(0o644); // Not executable
+    fs::set_permissions(&exe, perms).unwrap();
+
+    let mut ctx = PipelineContext::new(123);
+    ctx.app = Some(LibraryGame {
+        app_id: 123,
+        name: "Test Game".to_string(),
+        playtime_forever_minutes: None,
+        is_installed: true,
+        install_path: Some(tmp.path().to_string_lossy().to_string()),
+        local_manifest_ids: Default::default(),
+        update_available: false,
+        update_queued: false,
+        active_branch: "public".to_string(),
+        is_owned: true,
+        is_family_shared: false,
+        online_required: None,
+        platform: None,
+        from_windows_steam: false,
+    });
+    ctx.launch_info = Some(LaunchInfo {
+        app_id: 123,
+        id: "0".to_string(),
+        description: "Test".to_string(),
+        executable: "Game.AppImage".to_string(),
+        arguments: String::new(),
+        workingdir: None,
+        target: LaunchTarget::NativeLinux,
+    });
+    let mut spec = CommandSpec::default();
+    spec.program = exe.clone();
+    ctx.command_spec = Some(spec);
+
+    let stage = PreflightStage;
+    let res = stage.execute(&mut ctx).await;
+
+    assert!(res.is_ok(), "native game should self-heal: {:?}", res.err());
+    let mode = fs::metadata(&exe).unwrap().permissions().mode();
+    assert!(mode & 0o111 != 0, "exec bit should be set, mode {mode:o}");
+}
+
+#[tokio::test]
+#[cfg(unix)]
 async fn test_preflight_not_executable() {
     use std::os::unix::fs::PermissionsExt;
     let tmp = tempdir().unwrap();

--- a/vendor/steam-cdn/src/cdn/manifest/file.rs
+++ b/vendor/steam-cdn/src/cdn/manifest/file.rs
@@ -11,6 +11,9 @@ use tokio::{
 
 use crate::{cdn::inner::InnerClient, Error};
 
+/// Steam EDepotFileFlag::Executable bit.
+pub const FLAG_EXECUTABLE: u32 = 32;
+
 #[derive(Debug)]
 pub struct ChunkData {
     pub(super) sha: Vec<u8>,
@@ -238,6 +241,31 @@ impl ManifestFile {
             }
         }
         out.flush().await.map_err(|e| Error::Unexpected(e.to_string()))?;
+
+        #[cfg(unix)]
+        self.apply_unix_mode(target_path).await?;
+
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    async fn apply_unix_mode(&self, target_path: &std::path::Path) -> Result<(), Error> {
+        use std::os::unix::fs::PermissionsExt;
+
+        if self.flags & FLAG_EXECUTABLE == 0 {
+            return Ok(());
+        }
+        let metadata = tokio::fs::metadata(target_path)
+            .await
+            .map_err(|e| Error::Unexpected(e.to_string()))?;
+        let mut permissions = metadata.permissions();
+        if permissions.mode() & 0o111 != 0 {
+            return Ok(());
+        }
+        permissions.set_mode(permissions.mode() | 0o755);
+        tokio::fs::set_permissions(target_path, permissions)
+            .await
+            .map_err(|e| Error::Unexpected(e.to_string()))?;
         Ok(())
     }
 }


### PR DESCRIPTION
Issue #4 
- preflight self-heal for native Linux binaries
- fixing AppImage-bundled games.